### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,6 @@ Just run `make release` and the new binaries will be generated under the build d
 │ └── mongodb_exporter <--- Linux binary
 ```
 
-### Build the exporter
-The build process uses the dockerized version of goreleaser so you don't need to install Go.
-Just run `make release` and the new binaries will be generated under the build directory.
-```
-├── build
-│ ├── config.yaml
-│ ├── mongodb_exporter_7c73946_checksums.txt
-│ ├── mongodb_exporter-7c73946.darwin-amd64.tar.gz
-│ ├── mongodb_exporter-7c73946.linux-amd64.tar.gz
-│ ├── mongodb_exporter_darwin_amd64
-│ │ └── mongodb_exporter <--- MacOS binary
-│ └── mongodb_exporter_linux_amd64
-│ └── mongodb_exporter <--- Linux binary
-```
-
 ### Running the exporter
 If you built the exporter using the method mentioned in the previous section, the generated binaries are in `mongodb_exporter_linux_amd64/mongodb_exporter` or `mongodb_exporter_darwin_amd64/mongodb_exporter`
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you built the exporter using the method mentioned in the previous section, th
 
 #### Example
 ```
-mongodb_exporter_linux_amd64/mongodb_exporter --mongodbdsn=mongodb://127.0.0.1:17001
+mongodb_exporter_darwin_amd64/mongodb_exporter --mongodb.uri=mongodb://exporter:password@127.0.0.1:27017/admin
 ```
 #### Enabling collstats metrics gathering
 `--mongodb.collstats-colls` receives a list of databases and collections to monitor using collstats.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Currently, these metric sources are implemented:
 
  ### Build the exporter
 The build process uses the dockerized version of goreleaser so you don't need to install Go.
-Just run `make build` and the new binaries will be generated under the build directory.
+Just run `make release` and the new binaries will be generated under the build directory.
 ```
 ├── build
 │ ├── config.yaml
@@ -50,7 +50,7 @@ Just run `make build` and the new binaries will be generated under the build dir
 
 ### Build the exporter
 The build process uses the dockerized version of goreleaser so you don't need to install Go.
-Just run `make build` and the new binaries will be generated under the build directory.
+Just run `make release` and the new binaries will be generated under the build directory.
 ```
 ├── build
 │ ├── config.yaml


### PR DESCRIPTION
In contrast to the statement from the README.md `make build` requires an installed go version. Only `make release` works.



When all checks have passed and code is ready for the review, please add `pmm-review-exporters` as the reviewer. That would assign people from the review team automatically.